### PR TITLE
docs: add missing community contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,7 +56,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at .
+reported to the community leaders responsible for enforcement at <sanidhyyy@gmail.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 This project and everyone participating in it is governed by the
 [Figma Clone Code of Conduct](https://github.com/sanidhyy/figma-cloneblob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
-to .
+to <sanidhyyy@gmail.com>.
 
 ## I Have a Question
 
@@ -78,7 +78,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 #### How Do I Submit a Good Bug Report?
 
-> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to .
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <sanidhyyy@gmail.com>.
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,12 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+This project is maintained on the default branch. Please use the latest commit when reporting issues.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Report security vulnerabilities privately to <sanidhyyy@gmail.com>.
+Please do not open a public GitHub issue for security reports.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Reports will be reviewed as soon as possible. If a report is accepted, we will work on a fix.
+If it is declined, we will explain why.


### PR DESCRIPTION
## Summary
- fill empty community contact placeholders with sanidhyyy@gmail.com

## Changes
- `CODE_OF_CONDUCT.md`: enforcement at . -> enforcement at <sanidhyyy@gmail.com>.
- `CONTRIBUTING.md`: to . -> to <sanidhyyy@gmail.com>., sent by email to . -> sent by email to <sanidhyyy@gmail.com>.
- `SECURITY.md`: replace GitHub SECURITY template with report address sanidhyyy@gmail.com
